### PR TITLE
Fix package.json error when installing through npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "description": "A simple interface to apply features described in Gherkins to any test framework (BDD)",
   "main": "index.js",
   "scripts": {
-    "postinstall": "bower install",
+    "pretest": "bower install",
     "test": "npm run build && node jasmine-reporter.js && wct",
     "test2": "JASMINE_CONFIG_PATH=spec/support/jasmine.json jasmine && JASMINE_CONFIG_PATH=spec2/support/second_env.json jasmine",
     "wct": "wct",


### PR DESCRIPTION
Fixed by changing "pretest" instead of "postinstall" command.
